### PR TITLE
既知のナビゲーションバグの追跡の一歩として、ソートの単体テストを実装

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3945,6 +3945,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.7",
  "env_logger",
+ "filetime",
  "hex",
  "image 0.24.9",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,8 @@ tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
 tempfile = "3.3"
+filetime = "0.2"
+tauri = { version = "1.4.0", features = ["api-all"] }
 
 [build-dependencies]
 tauri-build = { version = "1.4", features = [] }

--- a/src-tauri/src/file_system.rs
+++ b/src-tauri/src/file_system.rs
@@ -5,16 +5,18 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::State;
 use sha2::{Sha256, Digest};
-use tauri::api::path::{home_dir};
+use tauri::api::path::home_dir;
+use std::sync::Mutex;
+use log::{info, debug, error};
 
 #[tauri::command]
 pub fn get_directory_contents(path: &str, state: State<'_, AppState>) -> Result<Vec<FileItem>, String> {
-    get_directory_contents_impl(path, state.inner())
+    get_directory_contents_impl(path, &state.inner().image_paths)
 }
 
-fn get_directory_contents_impl(path: &str, state: &AppState) -> Result<Vec<FileItem>, String> {
+fn get_directory_contents_impl(path: &str, image_paths: &Mutex<std::collections::HashMap<String, String>>) -> Result<Vec<FileItem>, String> {
     let mut items = Vec::new();
-    let mut image_paths = state.image_paths.lock().unwrap();
+    let mut image_paths = image_paths.lock().unwrap();
     
     match fs::read_dir(path) {
         Ok(entries) => {
@@ -55,13 +57,8 @@ fn get_directory_contents_impl(path: &str, state: &AppState) -> Result<Vec<FileI
         Err(e) => Err(format!("Failed to read directory: {}", e)),
     }
 }
-
 #[tauri::command]
 pub fn get_root_folders() -> Vec<FileItem> {
-    get_root_folders_impl()
-}
-
-fn get_root_folders_impl() -> Vec<FileItem> {
     let mut roots = Vec::new();
 
     if let Some(home) = home_dir() {
@@ -101,30 +98,66 @@ fn get_root_folders_impl() -> Vec<FileItem> {
     roots
 }
 
+
 #[tauri::command]
 pub fn get_full_image_list(path: &str, sort_by: SortBy, sort_order: SortOrder) -> Result<Vec<String>, String> {
-    get_full_image_list_impl(path, sort_by, sort_order)
-}
+    info!("get_full_image_list called with path: {}", path);
+    let dir_path = Path::new(path);
+    debug!("Directory path: {:?}", dir_path);
+    
+    let entries = match fs::read_dir(dir_path) {
+        Ok(entries) => entries,
+        Err(e) => {
+            error!("Failed to read directory: {:?}", e);
+            return Err(format!("Failed to read directory: {}", e));
+        }
+    };
 
-fn get_full_image_list_impl(path: &str, sort_by: SortBy, sort_order: SortOrder) -> Result<Vec<String>, String> {
-    let parent_dir = Path::new(path).parent().ok_or_else(|| "Invalid path".to_string())?;
-    let mut images: Vec<(PathBuf, std::fs::Metadata)> = fs::read_dir(parent_dir)
-        .map_err(|e| e.to_string())?
+    let mut images: Vec<(PathBuf, std::fs::Metadata)> = entries
         .filter_map(|entry| {
-            let entry = entry.ok()?;
-            let path = entry.path();
-            if path.is_file() && is_image(&path) {
-                let metadata = fs::metadata(&path).ok()?;
-                Some((path, metadata))
-            } else {
-                None
+            match entry {
+                Ok(entry) => {
+                    let path = entry.path();
+                    debug!("Checking file: {:?}", path);
+                    if path.is_file() {
+                        match is_image(&path) {
+                            true => {
+                                debug!("Found image: {:?}", path);
+                                match fs::metadata(&path) {
+                                    Ok(metadata) => Some((path, metadata)),
+                                    Err(e) => {
+                                        error!("Failed to get metadata for {:?}: {:?}", path, e);
+                                        None
+                                    }
+                                }
+                            },
+                            false => {
+                                debug!("Not an image: {:?}", path);
+                                None
+                            }
+                        }
+                    } else {
+                        debug!("Not a file: {:?}", path);
+                        None
+                    }
+                },
+                Err(e) => {
+                    error!("Error reading directory entry: {:?}", e);
+                    None
+                }
             }
         })
         .collect();
 
+    debug!("Collected images: {:?}", images);
+
     sort_images(&mut images, &sort_by, &sort_order);
 
-    Ok(images.into_iter().map(|(path, _)| path.to_string_lossy().into_owned()).collect())
+    let result: Vec<String> = images.into_iter()
+        .map(|(path, _)| path.to_string_lossy().into_owned())
+        .collect();
+    info!("Returning {} images", result.len());
+    Ok(result)
 }
 
 fn sort_images(images: &mut [(PathBuf, std::fs::Metadata)], sort_by: &SortBy, sort_order: &SortOrder) {
@@ -153,71 +186,150 @@ mod tests {
     use tempfile::TempDir;
     use std::fs::File;
     use std::io::Write;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use std::collections::HashMap;
+    use env_logger;
+    use std::path::PathBuf;
 
-    fn create_test_directory() -> TempDir {
+    fn create_test_directory() -> (TempDir, PathBuf) {
         let temp_dir = TempDir::new().unwrap();
-        let base_path = temp_dir.path();
+        let base_path = temp_dir.path().to_path_buf();
+        info!("Creating test directory at: {:?}", base_path);
 
-        // Create some test files and directories
-        fs::create_dir(base_path.join("dir1")).unwrap();
-        fs::create_dir(base_path.join("dir2")).unwrap();
-        File::create(base_path.join("file1.txt")).unwrap().write_all(b"Hello").unwrap();
-        File::create(base_path.join("image1.jpg")).unwrap().write_all(b"JPEG").unwrap();
-        File::create(base_path.join("image2.png")).unwrap().write_all(b"PNG").unwrap();
+        let file_data = [
+            ("file1.txt", "Hello", 0),
+            ("file2.jpg", "Hello World", 1),
+            ("file3.png", "Hello World!", 2),
+        ];
 
-        temp_dir
+        for (name, content, delay) in file_data.iter() {
+            let path = base_path.join(name);
+            info!("Creating file: {:?}", path);
+            let mut file = File::create(&path).expect("Failed to create file");
+            file.write_all(content.as_bytes()).expect("Failed to write content");
+            sleep(Duration::from_secs(*delay));
+            let metadata = file.metadata().expect("Failed to get metadata");
+            let mtime = metadata.modified().expect("Failed to get modification time") + Duration::from_secs(*delay);
+            filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(mtime)).expect("Failed to set modification time");
+            
+            if !path.exists() {
+                error!("Failed to create file: {:?}", path);
+            } else {
+                info!("Successfully created file: {:?}", path);
+            }
+        }
+
+        (temp_dir, base_path)
     }
 
     #[test]
     fn test_get_directory_contents() {
-        let temp_dir = create_test_directory();
-        let state = AppState::new();
-        let contents = get_directory_contents_impl(temp_dir.path().to_str().unwrap(), &state).unwrap();
+        let (_temp_dir, base_path) = create_test_directory();
+        let image_paths = Mutex::new(HashMap::new());
+        
+        let contents = get_directory_contents_impl(base_path.to_str().unwrap(), &image_paths).unwrap();
 
-        assert_eq!(contents.len(), 5);
-        assert!(contents.iter().any(|item| item.name == "dir1" && item.is_dir));
-        assert!(contents.iter().any(|item| item.name == "file1.txt" && !item.is_dir));
-        assert!(contents.iter().any(|item| item.name == "image1.jpg" && !item.is_dir));
-    }
-
-    #[test]
-    fn test_get_root_folders() {
-        let roots = get_root_folders_impl();
-        assert!(!roots.is_empty());
-        assert!(roots.iter().any(|item| item.name == "Home"));
-        assert!(roots.iter().any(|item| item.name == "Root"));
+        assert_eq!(contents.len(), 3, "Expected 3 files, but found {}", contents.len());
+        assert!(contents.iter().any(|item| item.name == "file1.txt"));
+        assert!(contents.iter().any(|item| item.name == "file2.jpg"));
+        assert!(contents.iter().any(|item| item.name == "file3.png"));
     }
 
     #[test]
     fn test_get_full_image_list() {
-        let temp_dir = create_test_directory();
-        let image_list = get_full_image_list_impl(
-            temp_dir.path().join("image1.jpg").to_str().unwrap(),
-            SortBy::Name,
-            SortOrder::Asc
-        ).unwrap();
+        let _ = env_logger::builder().is_test(true).try_init();
+    
+        let (_temp_dir, dir_path) = create_test_directory();
+        info!("Test directory: {:?}", dir_path);
+        
+        for entry in fs::read_dir(&dir_path).unwrap() {
+            let entry = entry.unwrap();
+            info!("File in test directory: {:?}", entry.path());
+        }
+    
+        // dir_path を直接使用
+        let result = get_full_image_list(dir_path.to_str().unwrap(), SortBy::Name, SortOrder::Asc);
+        match result {
+            Ok(images) => {
+                info!("Result: {:?}", images);
+                assert_eq!(images.len(), 2, "Expected 2 image files, but found {}", images.len());
+                if images.len() >= 2 {
+                    assert!(images[0].ends_with("file2.jpg"), "Expected file2.jpg, got {}", images[0]);
+                    assert!(images[1].ends_with("file3.png"), "Expected file3.png, got {}", images[1]);
+                }
+            },
+            Err(e) => {
+                error!("Error in get_full_image_list: {:?}", e);
+                panic!("get_full_image_list failed: {}", e);
+            }
+        }
+    }
+    #[test]
+    fn test_sort_images() {
+        let (_temp_dir, base_path) = create_test_directory();
 
-        assert_eq!(image_list.len(), 2);
-        assert!(image_list.iter().any(|path| path.ends_with("image1.jpg")));
-        assert!(image_list.iter().any(|path| path.ends_with("image2.png")));
+        let mut images: Vec<(PathBuf, std::fs::Metadata)> = fs::read_dir(&base_path)
+            .unwrap()
+            .filter_map(|entry| {
+                let entry = entry.unwrap();
+                let metadata = entry.metadata().unwrap();
+                Some((entry.path(), metadata))
+            })
+            .collect();
+
+        sort_images(&mut images, &SortBy::Name, &SortOrder::Asc);
+        assert_eq!(images.len(), 3, "Expected 3 files, but found {}", images.len());
+        assert_eq!(images[0].0.file_name().unwrap(), "file1.txt");
+        assert_eq!(images[1].0.file_name().unwrap(), "file2.jpg");
+        assert_eq!(images[2].0.file_name().unwrap(), "file3.png");
     }
 
     #[test]
-    fn test_sort_images() {
-        let temp_dir = create_test_directory();
-        let base_path = temp_dir.path();
+    fn test_sort_images_by_date() {
+        let (_temp_dir, base_path) = create_test_directory();
 
-        let mut images: Vec<(PathBuf, std::fs::Metadata)> = vec![
-            (base_path.join("image1.jpg"), fs::metadata(base_path.join("image1.jpg")).unwrap()),
-            (base_path.join("image2.png"), fs::metadata(base_path.join("image2.png")).unwrap()),
-        ];
+        let mut images: Vec<(PathBuf, std::fs::Metadata)> = fs::read_dir(&base_path)
+            .unwrap()
+            .filter_map(|entry| {
+                let entry = entry.unwrap();
+                let metadata = entry.metadata().unwrap();
+                Some((entry.path(), metadata))
+            })
+            .collect();
 
-        sort_images(&mut images, &SortBy::Name, &SortOrder::Asc);
-        assert_eq!(images[0].0.file_name().unwrap(), "image1.jpg");
-        assert_eq!(images[1].0.file_name().unwrap(), "image2.png");
+        sort_images(&mut images, &SortBy::Date, &SortOrder::Asc);
+        assert_eq!(images[0].0.file_name().unwrap(), "file1.txt", "Expected file1.txt to be oldest");
+        assert_eq!(images[1].0.file_name().unwrap(), "file2.jpg", "Expected file2.jpg to be second oldest");
+        assert_eq!(images[2].0.file_name().unwrap(), "file3.png", "Expected file3.png to be newest");
 
-        sort_images(&mut images, &SortBy::Name, &SortOrder::Desc);
-        assert_eq!(images[0].0.file_name().unwrap(), "image2.png");
-        assert_eq!(images[1].0.file_name().unwrap(), "image1.jpg");
+        sort_images(&mut images, &SortBy::Date, &SortOrder::Desc);
+        assert_eq!(images[0].0.file_name().unwrap(), "file3.png", "Expected file3.png to be newest");
+        assert_eq!(images[1].0.file_name().unwrap(), "file2.jpg", "Expected file2.jpg to be second newest");
+        assert_eq!(images[2].0.file_name().unwrap(), "file1.txt", "Expected file1.txt to be oldest");
+    }
+
+    #[test]
+    fn test_sort_images_by_size() {
+        let (_temp_dir, base_path) = create_test_directory();
+
+        let mut images: Vec<(PathBuf, std::fs::Metadata)> = fs::read_dir(&base_path)
+            .unwrap()
+            .filter_map(|entry| {
+                let entry = entry.unwrap();
+                let metadata = entry.metadata().unwrap();
+                Some((entry.path(), metadata))
+            })
+            .collect();
+
+        sort_images(&mut images, &SortBy::Size, &SortOrder::Asc);
+        assert_eq!(images[0].0.file_name().unwrap(), "file1.txt");
+        assert_eq!(images[1].0.file_name().unwrap(), "file2.jpg");
+        assert_eq!(images[2].0.file_name().unwrap(), "file3.png");
+
+        sort_images(&mut images, &SortBy::Size, &SortOrder::Desc);
+        assert_eq!(images[0].0.file_name().unwrap(), "file3.png");
+        assert_eq!(images[1].0.file_name().unwrap(), "file2.jpg");
+        assert_eq!(images[2].0.file_name().unwrap(), "file1.txt");
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,10 +3,13 @@ mod image_processing;
 mod config;
 mod models;
 mod utils;
-
+use log::LevelFilter;
 use tauri::Manager;
 
 fn main() {
+    env_logger::Builder::from_default_env()
+        .filter_level(LevelFilter::Debug)
+        .init();
     tauri::Builder::default()
         .setup(|app| {
             let window = app.get_window("main").expect("Failed to get main window");

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -20,12 +20,16 @@ pub fn get_cache_path(original_path: &str) -> PathBuf {
 }
 
 
+use log::debug;
+
 pub fn is_image(path: &Path) -> bool {
     let extensions = ["jpg", "jpeg", "png", "gif", "bmp", "webp"];
-    path.extension()
+    let result = path.extension()
         .and_then(|ext| ext.to_str())
         .map(|ext| extensions.contains(&ext.to_lowercase().as_str()))
-        .unwrap_or(false)
+        .unwrap_or(false);
+    debug!("is_image check for {:?}: {}", path, result);
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
rust側のソートは正しく動作していそうに見える。